### PR TITLE
feat: add scheduled scan and Feishu push notification

### DIFF
--- a/background.js
+++ b/background.js
@@ -341,9 +341,185 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
       chrome.runtime.sendMessage({ type: 'scanResult', data: results });
     });
   }
+
+  if (request.action === 'updateScheduleConfig') {
+    const { scheduleConfig } = request;
+    setupAlarm(scheduleConfig);
+    sendResponse({ success: true });
+    return true;
+  }
+
   return true;
 });
 
+// ===== 定时任务 & 飞书推送 =====
+
+const ALARM_NAME = 'dailyMedalScan';
+
+function sendToFeishu(webhookUrl, results, scanTime) {
+  const totalMedals = results.reduce((sum, r) => sum + r.count, 0);
+  const validSites = results.filter(r => r.count > 0);
+
+  const lines = [
+    [{ tag: 'text', text: `扫描时间: ${scanTime}` }],
+    [{ tag: 'text', text: `共扫描 ${results.length} 个站点，发现 ${totalMedals} 个可购买勋章` }],
+    [{ tag: 'text', text: '' }]
+  ];
+
+  if (validSites.length === 0) {
+    lines.push([{ tag: 'text', text: '😴 没有发现可购买的勋章' }]);
+  } else {
+    for (const site of validSites) {
+      lines.push([
+        { tag: 'text', text: `\n📌 ${site.siteName}（${site.count}个）` }
+      ]);
+      for (const medal of site.medals) {
+        const parts = [`  • ${medal.name}`];
+        if (medal.price) parts.push(`💰${medal.price}`);
+        if (medal.duration) parts.push(`⏱${medal.duration}`);
+        if (medal.bonus) parts.push(`📈${medal.bonus}`);
+        lines.push([{ tag: 'text', text: parts.join(' ') }]);
+      }
+    }
+  }
+
+  const payload = {
+    msg_type: 'post',
+    content: {
+      post: {
+        zh_cn: {
+          title: '🏅 PT勋章扫描报告',
+          content: lines
+        }
+      }
+    }
+  };
+
+  return fetchWithTimeout(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  }, 15000);
+}
+
+function setupAlarm(scheduleConfig) {
+  chrome.alarms.clear(ALARM_NAME, () => {
+    if (!scheduleConfig || !scheduleConfig.enabled) return;
+
+    const [hour, minute] = scheduleConfig.time.split(':').map(Number);
+    const now = new Date();
+    const scheduled = new Date(now);
+    scheduled.setHours(hour, minute, 0, 0);
+    if (scheduled <= now) scheduled.setDate(scheduled.getDate() + 1);
+    const delayMs = scheduled - now;
+    const delayMinutes = Math.ceil(delayMs / 60000);
+
+    chrome.alarms.create(ALARM_NAME, {
+      delayInMinutes: delayMinutes,
+      periodInMinutes: 1440
+    });
+  });
+}
+
+async function performScheduledScan() {
+  const { sites, scheduleConfig } = await chrome.storage.local.get(['sites', 'scheduleConfig']);
+  const webhookUrl = scheduleConfig?.webhookUrl;
+
+  if (!sites || sites.length === 0) return;
+  if (!webhookUrl) return;
+
+  const results = [];
+
+  for (const site of sites) {
+    const [siteName, siteUrl] = site.split('|');
+    try {
+      const domain = getCookieDomain(siteUrl);
+      const [cookiesMain, cookiesSub] = await Promise.all([
+        chrome.cookies.getAll({ url: siteUrl }),
+        chrome.cookies.getAll({ domain })
+      ]);
+      const cookies = [...new Set([...cookiesMain, ...cookiesSub])];
+
+      if (cookies.length === 0) continue;
+
+      const response = await fetchWithTimeout(siteUrl, {
+        headers: {
+          Cookie: cookies.map(c => `${c.name}=${c.value}`).join('; '),
+          'User-Agent': navigator.userAgent
+        }
+      }, 10000);
+
+      if (!response.ok) continue;
+
+      const html = await response.text();
+      let medals = siteUrl.includes('buycenter.php')
+        ? extractMedalsFromBuyCenter(html)
+        : extractMedalsFromHtml(html);
+
+      for (let i = 1; i < 15; i++) {
+        const re = new RegExp(`href\\s*=\\s*["']\\?page=${i}["']`, 'g');
+        if ((html.match(re) || []).length > 0) {
+          try {
+            const newUrl = siteUrl + '?page=' + i;
+            const r2 = await fetchWithTimeout(newUrl, {
+              headers: {
+                Cookie: cookies.map(c => `${c.name}=${c.value}`).join('; '),
+                'User-Agent': navigator.userAgent
+              }
+            }, 10000);
+            const h2 = await r2.text();
+            medals = medals.concat(extractMedalsFromHtml(h2));
+          } catch {
+            break;
+          }
+        } else {
+          break;
+        }
+      }
+
+      results.push({ siteName, count: medals.length, url: siteUrl, medals });
+    } catch {
+      // skip failed sites silently
+    }
+  }
+
+  const now = new Date();
+  const scanTime = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')} ${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+  const dateStr = now.toISOString().slice(0, 10);
+  const timestamp = Date.now();
+
+  const scanEntry = { timestamp, dateStr, results };
+  const { scanHistory } = await chrome.storage.local.get(['scanHistory']);
+  const history = scanHistory || [];
+  history.push(scanEntry);
+  if (history.length > 60) history.shift();
+  await chrome.storage.local.set({ scanResults: results, scanHistory: history });
+
+  try {
+    await sendToFeishu(webhookUrl, results, scanTime);
+  } catch {
+    // silently fail
+  }
+}
+
+chrome.runtime.onStartup?.addListener(() => {
+  chrome.storage.local.get(['scheduleConfig'], ({ scheduleConfig }) => {
+    setupAlarm(scheduleConfig);
+  });
+});
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.storage.local.get(['scheduleConfig'], ({ scheduleConfig }) => {
+    setupAlarm(scheduleConfig);
+  });
+});
+
+chrome.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name === ALARM_NAME) {
+    performScheduledScan();
+  }
+});
+
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { getCookieDomain, fetchWithTimeout, extractMedalsFromHtml, extractTdText, getColumnLayout, extractMedalsFromBuyCenter };
+  module.exports = { getCookieDomain, fetchWithTimeout, extractMedalsFromHtml, extractTdText, getColumnLayout, extractMedalsFromBuyCenter, sendToFeishu, setupAlarm, performScheduledScan, ALARM_NAME };
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "PT勋章扫描器",
   "version": "1.0",
-  "permissions": ["cookies", "storage", "activeTab"],
+  "permissions": ["cookies", "storage", "activeTab", "alarms"],
      "host_permissions": [
     "<all_urls>"
   ],

--- a/options/options.html
+++ b/options/options.html
@@ -367,6 +367,122 @@
       gap: 8px;
       flex-wrap: wrap;
     }
+
+    /* 定时任务配置样式 */
+    .schedule-card {
+      margin-top: 25px;
+    }
+
+    .schedule-row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin: 12px 0;
+      flex-wrap: wrap;
+    }
+
+    .schedule-row label {
+      font-size: 13px;
+      color: #555;
+      min-width: 80px;
+      font-weight: 500;
+    }
+
+    .schedule-row input[type="time"] {
+      padding: 8px 12px;
+      border: 1px solid #e0e0e0;
+      border-radius: 8px;
+      font-size: 14px;
+      background: #fafbfc;
+      color: #333;
+      font-family: inherit;
+    }
+
+    .schedule-row input[type="time"]:focus {
+      outline: none;
+      border-color: #667eea;
+      box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+    }
+
+    .schedule-row input[type="url"] {
+      flex: 1;
+      min-width: 200px;
+      padding: 8px 12px;
+      border: 1px solid #e0e0e0;
+      border-radius: 8px;
+      font-size: 13px;
+      background: #fafbfc;
+      color: #555;
+      font-family: inherit;
+    }
+
+    .schedule-row input[type="url"]:focus {
+      outline: none;
+      border-color: #667eea;
+      box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+    }
+
+    .schedule-row .hint {
+      font-size: 11px;
+      color: #aaa;
+      margin-left: 4px;
+    }
+
+    .toggle-switch {
+      position: relative;
+      display: inline-block;
+      width: 44px;
+      height: 24px;
+      flex-shrink: 0;
+    }
+
+    .toggle-switch input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+
+    .toggle-slider {
+      position: absolute;
+      cursor: pointer;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: #ccc;
+      border-radius: 24px;
+      transition: 0.3s;
+    }
+
+    .toggle-slider::before {
+      content: '';
+      position: absolute;
+      height: 18px;
+      width: 18px;
+      left: 3px;
+      bottom: 3px;
+      background: white;
+      border-radius: 50%;
+      transition: 0.3s;
+    }
+
+    .toggle-switch input:checked + .toggle-slider {
+      background: linear-gradient(135deg, #667eea, #764ba2);
+    }
+
+    .toggle-switch input:checked + .toggle-slider::before {
+      transform: translateX(20px);
+    }
+
+    .schedule-status {
+      font-size: 13px;
+      color: #888;
+    }
+
+    .schedule-status.active {
+      color: #4CAF50;
+      font-weight: 500;
+    }
   </style>
 </head>
 <body>
@@ -430,6 +546,36 @@
         <div id="resultList"></div>
         <div id="resultStats"></div>
       </div>
+    </div>
+  </div>
+
+  <div class="card schedule-card">
+    <h3>⏰ 定时任务配置</h3>
+
+    <div class="schedule-row">
+      <label>启用定时</label>
+      <label class="toggle-switch">
+        <input type="checkbox" id="scheduleToggle">
+        <span class="toggle-slider"></span>
+      </label>
+      <span id="scheduleStatus" class="schedule-status">已禁用</span>
+    </div>
+
+    <div class="schedule-row">
+      <label>执行时间</label>
+      <input type="time" id="scheduleTime" value="08:00">
+      <span class="hint">每日固定时间自动扫描</span>
+    </div>
+
+    <div class="schedule-row">
+      <label>Webhook URL</label>
+      <input type="url" id="webhookUrl" placeholder="https://open.feishu.cn/open-apis/bot/v2/hook/xxxxxx" style="flex:1;">
+      <span class="hint">飞书机器人 webhook 地址</span>
+    </div>
+
+    <div class="action-buttons" style="margin-top: 16px;">
+      <button id="saveScheduleBtn" class="btn-save">💾 保存定时配置</button>
+      <button id="testWebhookBtn" class="btn-detect" style="background: linear-gradient(135deg, #43e97b, #38f9d7); color: #1a3a2a;">📤 测试推送</button>
     </div>
   </div>
 

--- a/options/options.js
+++ b/options/options.js
@@ -14,7 +14,13 @@ document.addEventListener('DOMContentLoaded', () => {
     diffToggleBtn: document.getElementById('diffToggleBtn'),
     debugExportBtn: document.getElementById('debugExportBtn'),
     detectBtn: document.getElementById('detectBtn'),
-    detectSummary: document.getElementById('detectSummary')
+    detectSummary: document.getElementById('detectSummary'),
+    scheduleToggle: document.getElementById('scheduleToggle'),
+    scheduleTime: document.getElementById('scheduleTime'),
+    webhookUrl: document.getElementById('webhookUrl'),
+    scheduleStatus: document.getElementById('scheduleStatus'),
+    saveScheduleBtn: document.getElementById('saveScheduleBtn'),
+    testWebhookBtn: document.getElementById('testWebhookBtn')
   };
 
   let diffMode = false;
@@ -166,11 +172,18 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     }
 
-    chrome.storage.local.get(['sites', 'scanResults', 'scanHistory'], ({ sites, scanResults, scanHistory }) => {
+    chrome.storage.local.get(['sites', 'scanResults', 'scanHistory', 'scheduleConfig'], ({ sites, scanResults, scanHistory, scheduleConfig }) => {
       elements.sitesTextarea.value = sites?.join('\n') || '';
       if (scanResults) updateResultDisplay(scanResults);
       if (scanHistory && scanHistory.length >= 2) {
         previousResults = scanHistory[scanHistory.length - 2].results;
+      }
+
+      if (scheduleConfig) {
+        elements.scheduleToggle.checked = scheduleConfig.enabled || false;
+        if (scheduleConfig.time) elements.scheduleTime.value = scheduleConfig.time;
+        if (scheduleConfig.webhookUrl) elements.webhookUrl.value = scheduleConfig.webhookUrl;
+        updateScheduleStatus();
       }
     });
 
@@ -394,6 +407,74 @@ document.addEventListener('DOMContentLoaded', () => {
           ✅ 已登录：<strong>${found.length}</strong> 个（新增 <strong>${newSites.length}</strong> 个）<br>
           ❌ 未登录：<strong>${notFound.length}</strong> 个
         `;
+      });
+    });
+
+    function updateScheduleStatus() {
+      const enabled = elements.scheduleToggle.checked;
+      elements.scheduleStatus.textContent = enabled ? '已启用' : '已禁用';
+      elements.scheduleStatus.className = 'schedule-status' + (enabled ? ' active' : '');
+    }
+
+    elements.scheduleToggle.addEventListener('change', updateScheduleStatus);
+
+    elements.saveScheduleBtn.addEventListener('click', () => {
+      const scheduleConfig = {
+        enabled: elements.scheduleToggle.checked,
+        time: elements.scheduleTime.value || '08:00',
+        webhookUrl: elements.webhookUrl.value.trim()
+      };
+
+      chrome.storage.local.set({ scheduleConfig }, () => {
+        addLog(`⏰ 定时配置已保存（${scheduleConfig.enabled ? '已启用' : '已禁用'}，每日 ${scheduleConfig.time} 执行）`);
+      });
+
+      chrome.runtime.sendMessage({ action: 'updateScheduleConfig', scheduleConfig });
+    });
+
+    elements.testWebhookBtn.addEventListener('click', () => {
+      const webhookUrl = elements.webhookUrl.value.trim();
+      if (!webhookUrl) {
+        addLog('❌ 请先填写 Webhook URL', true);
+        return;
+      }
+
+      elements.testWebhookBtn.disabled = true;
+      elements.testWebhookBtn.innerHTML = '⏳ 发送中...';
+
+      const testPayload = {
+        msg_type: 'post',
+        content: {
+          post: {
+            zh_cn: {
+              title: '🧪 PT勋章扫描器 - 测试消息',
+              content: [
+                [{ tag: 'text', text: '这是一条测试推送消息' }],
+                [{ tag: 'text', text: '如果收到此消息，说明 Webhook 配置正确 ✅' }],
+                [{ tag: 'text', text: `发送时间: ${new Date().toLocaleString()}` }]
+              ]
+            }
+          }
+        }
+      };
+
+      fetch(webhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(testPayload)
+      }).then(response => {
+        if (response.ok) {
+          addLog('✅ 测试推送成功！请检查飞书机器人消息');
+        } else {
+          return response.text().then(text => {
+            addLog(`❌ 推送失败 (HTTP ${response.status}): ${text}`, true);
+          });
+        }
+      }).catch(error => {
+        addLog(`❌ 推送失败: ${error.message}`, true);
+      }).finally(() => {
+        elements.testWebhookBtn.disabled = false;
+        elements.testWebhookBtn.innerHTML = '📤 测试推送';
       });
     });
 

--- a/tests/integration/messaging.test.js
+++ b/tests/integration/messaging.test.js
@@ -28,6 +28,11 @@ function mark(name, ok) {
 console.log('\n━━━ 消息传递集成测试 ━━━');
 
 async function runAll() {
+  const fs = require('fs');
+  const path = require('path');
+  const bgContent = fs.readFileSync(path.resolve(__dirname, '../../background.js'), 'utf-8');
+  const optContent = fs.readFileSync(path.resolve(__dirname, '../../options/options.js'), 'utf-8');
+
   // ============================================================
   // 1. 消息协议一致性（同步）
   // ============================================================
@@ -52,11 +57,6 @@ async function runAll() {
   }
 
   try {
-    const fs = require('fs');
-    const path = require('path');
-    const bgContent = fs.readFileSync(path.resolve(__dirname, '../../background.js'), 'utf-8');
-    const optContent = fs.readFileSync(path.resolve(__dirname, '../../options/options.js'), 'utf-8');
-
     const bgTypes = bgContent.match(/type:\s*['"](\w+)['"]/g) || [];
     const optTypes = optContent.match(/message\.type\s*===\s*['"](\w+)['"]/g) || [];
 
@@ -67,6 +67,22 @@ async function runAll() {
     mark('scanResult type 前后端匹配', true);
   } catch (e) {
     mark('scanResult type 前后端匹配', false);
+    console.log(`     ${e.message}`);
+  }
+
+  try {
+    const bgActions = bgContent.match(/action\s*===\s*['"](\w+)['"]/g) || [];
+    const optActions = optContent.match(/action:\s*['"](\w+)['"]/g) || [];
+
+    assert(bgActions.some(a => a.includes('startScan')), 'background应处理startScan');
+    assert(bgActions.some(a => a.includes('detectSites')), 'background应处理detectSites');
+    assert(bgActions.some(a => a.includes('updateScheduleConfig')), 'background应处理updateScheduleConfig');
+    assert(optActions.some(a => a.includes('startScan')), 'options应发送startScan');
+    assert(optActions.some(a => a.includes('detectSites')), 'options应发送detectSites');
+    assert(optActions.some(a => a.includes('updateScheduleConfig')), 'options应发送updateScheduleConfig');
+    mark('startScan action 前后端匹配', true);
+  } catch (e) {
+    mark('startScan action 前后端匹配', false);
     console.log(`     ${e.message}`);
   }
 

--- a/tests/mocks/chrome-mock.js
+++ b/tests/mocks/chrome-mock.js
@@ -34,7 +34,7 @@ function createChromeMock(config = {}) {
           } else if (typeof keys === 'string') {
             result[keys] = _storage.get(keys);
           }
-          if (callback) setTimeout(() => callback(result), 0);
+          if (callback) callback(result);
           return Promise.resolve(result);
         },
         set(items, callback) {
@@ -82,10 +82,24 @@ function createChromeMock(config = {}) {
         removeListener() { listeners.delete('runtime.onMessage'); }
       },
       onInstalled: new ChromeEvent(),
+      onStartup: new ChromeEvent(),
       openOptionsPage() {
         mock._optionsPageOpened = true;
         return Promise.resolve();
       }
+    },
+
+    alarms: {
+      _created: [],
+      _cleared: false,
+      create(name, options) {
+        mock.alarms._created.push({ name, options });
+      },
+      clear(name, callback) {
+        mock.alarms._cleared = true;
+        if (callback) setTimeout(callback, 0);
+      },
+      onAlarm: new ChromeEvent()
     },
 
     tabs: {
@@ -107,6 +121,8 @@ function createChromeMock(config = {}) {
       mock._sentMessages = [];
       mock._optionsPageOpened = false;
       mock._lastResponse = null;
+      mock.alarms._created = [];
+      mock.alarms._cleared = false;
     }
   };
 

--- a/tests/unit/background.test.js
+++ b/tests/unit/background.test.js
@@ -483,6 +483,142 @@ test('buycenter空HTML返回空数组', () => {
 });
 
 // ============================================================
+// sendToFeishu
+// ============================================================
+console.log('\n  ▶ sendToFeishu');
+
+test('sendToFeishu 发送POST请求', async () => {
+  let capturedUrl, capturedOptions;
+  const originalFetch = global.fetch;
+  global.fetch = (url, options) => {
+    capturedUrl = url;
+    capturedOptions = options;
+    return Promise.resolve({ ok: true });
+  };
+
+  const results = [{ siteName: '测试站', count: 2, url: 'https://test.com', medals: [{ name: '勋章A', price: '1000' }, { name: '勋章B', duration: '30天' }] }];
+  await bg.sendToFeishu('https://webhook.test', results, '2026-05-14 10:00');
+
+  assertEqual(capturedUrl, 'https://webhook.test');
+  assertEqual(capturedOptions.method, 'POST');
+  assertEqual(capturedOptions.headers['Content-Type'], 'application/json');
+
+  const body = JSON.parse(capturedOptions.body);
+  assertEqual(body.msg_type, 'post');
+  assert(body.content.post.zh_cn.title.includes('PT勋章扫描报告'));
+  assert(body.content.post.zh_cn.content.length > 0);
+
+  global.fetch = originalFetch;
+});
+
+test('sendToFeishu 空结果也发送', async () => {
+  let capturedBody;
+  const originalFetch = global.fetch;
+  global.fetch = (url, options) => {
+    capturedBody = JSON.parse(options.body);
+    return Promise.resolve({ ok: true });
+  };
+
+  await bg.sendToFeishu('https://webhook.test', [], '2026-05-14 10:00');
+  assert(capturedBody.content.post.zh_cn.content.some(line =>
+    line.some(block => block.text && block.text.includes('没有发现'))
+  ));
+
+  global.fetch = originalFetch;
+});
+
+test('sendToFeishu 包含勋章详情', async () => {
+  let capturedBody;
+  const originalFetch = global.fetch;
+  global.fetch = (url, options) => {
+    capturedBody = JSON.parse(options.body);
+    return Promise.resolve({ ok: true });
+  };
+
+  const results = [{ siteName: '测试站', count: 1, url: 'https://test.com', medals: [{ name: '稀有勋章', price: '5000', duration: '永久', bonus: '2%' }] }];
+  await bg.sendToFeishu('https://webhook.test', results, '2026-05-14 10:00');
+
+  const allText = capturedBody.content.post.zh_cn.content.map(line => line.map(b => b.text).join('')).join('');
+  assert(allText.includes('稀有勋章'));
+  assert(allText.includes('5000'));
+  assert(allText.includes('永久'));
+
+  global.fetch = originalFetch;
+});
+
+// ============================================================
+// setupAlarm
+// ============================================================
+console.log('\n  ▶ setupAlarm');
+
+test('setupAlarm 禁用时不创建alarm', () => {
+  global.chrome.alarms._created = [];
+  global.chrome.alarms._cleared = false;
+  const origClear = global.chrome.alarms.clear;
+  global.chrome.alarms.clear = (name, cb) => {
+    global.chrome.alarms._cleared = true;
+    if (cb) cb();
+  };
+  bg.setupAlarm({ enabled: false, time: '08:00' });
+  assert(global.chrome.alarms._cleared);
+  assertEqual(global.chrome.alarms._created.length, 0);
+  global.chrome.alarms.clear = origClear;
+});
+
+test('setupAlarm 启用时创建alarm', () => {
+  const origClear = global.chrome.alarms.clear;
+  global.chrome.alarms.clear = (name, cb) => {
+    global.chrome.alarms._cleared = true;
+    if (cb) cb();
+  };
+  global.chrome.alarms._created = [];
+  global.chrome.alarms._cleared = false;
+  bg.setupAlarm({ enabled: true, time: '08:00' });
+  assert(global.chrome.alarms._cleared);
+  assertEqual(global.chrome.alarms._created.length, 1);
+  assertEqual(global.chrome.alarms._created[0].name, bg.ALARM_NAME);
+  assertEqual(global.chrome.alarms._created[0].options.periodInMinutes, 1440);
+  global.chrome.alarms.clear = origClear;
+});
+
+test('setupAlarm null配置不创建alarm', () => {
+  global.chrome.alarms._created = [];
+  global.chrome.alarms._cleared = false;
+  const origClear = global.chrome.alarms.clear;
+  global.chrome.alarms.clear = (name, cb) => {
+    global.chrome.alarms._cleared = true;
+    if (cb) cb();
+  };
+  bg.setupAlarm(null);
+  assert(global.chrome.alarms._cleared);
+  assertEqual(global.chrome.alarms._created.length, 0);
+  global.chrome.alarms.clear = origClear;
+});
+
+// ============================================================
+// updateScheduleConfig 消息处理
+// ============================================================
+console.log('\n  ▶ updateScheduleConfig 消息');
+
+test('updateScheduleConfig 消息触发setupAlarm', () => {
+  const origClear = global.chrome.alarms.clear;
+  global.chrome.alarms.clear = (name, cb) => {
+    global.chrome.alarms._cleared = true;
+    if (cb) cb();
+  };
+
+  const msgHandler = global.chrome._listeners.get('runtime.onMessage');
+  assert(msgHandler, 'message handler should exist');
+
+  msgHandler({ action: 'updateScheduleConfig', scheduleConfig: { enabled: true, time: '10:00' } }, {}, () => {});
+  assert(global.chrome.alarms._cleared);
+  assertEqual(global.chrome.alarms._created.length, 1);
+  assertEqual(global.chrome.alarms._created[0].name, bg.ALARM_NAME);
+
+  global.chrome.alarms.clear = origClear;
+});
+
+// ============================================================
 // 汇总
 // ============================================================
 console.log(`\n  ━━━ background.js: ${passed}/${tests} 通过 ━━━`);

--- a/tests/unit/options.test.js
+++ b/tests/unit/options.test.js
@@ -257,7 +257,64 @@ test('无勋章站点不显示', () => {
 });
 
 // ============================================================
-// 5. Diff模式高亮
+// 5. 定时任务配置
+// ============================================================
+console.log('\n  ▶ 定时任务配置');
+
+test('定时配置DOM元素存在', () => {
+  const chromeMock = createChromeMock();
+  setupDOM();
+  loadOptions(chromeMock);
+
+  const ids = ['scheduleToggle', 'scheduleTime', 'webhookUrl', 'scheduleStatus', 'saveScheduleBtn', 'testWebhookBtn'];
+  ids.forEach(id => {
+    const el = document.getElementById(id);
+    assert(el !== null, `元素 #${id} 应存在`);
+  });
+});
+
+test('定时配置从storage加载', () => {
+  const chromeMock = createChromeMock();
+  chromeMock._storage.set('scheduleConfig', { enabled: true, time: '09:30', webhookUrl: 'https://webhook.test/hook' });
+  chromeMock._storage.set('sites', ['SiteX|https://x.com/medal.php']);
+  setupDOM();
+  loadOptions(chromeMock);
+
+  assert(document.getElementById('scheduleToggle').checked, 'toggle应被勾选');
+  assertEqual(document.getElementById('scheduleTime').value, '09:30');
+  assertEqual(document.getElementById('webhookUrl').value, 'https://webhook.test/hook');
+  assertContains(document.getElementById('scheduleStatus').textContent, '已启用');
+});
+
+test('保存定时配置写入storage并发送消息', () => {
+  const chromeMock = createChromeMock();
+  chromeMock._storage.set('sites', ['SiteX|https://x.com/medal.php']);
+  setupDOM();
+  loadOptions(chromeMock);
+
+  const toggle = document.getElementById('scheduleToggle');
+  const timeInput = document.getElementById('scheduleTime');
+  const urlInput = document.getElementById('webhookUrl');
+
+  toggle.checked = true;
+  timeInput.value = '07:00';
+  urlInput.value = 'https://feishu.webhook/test';
+
+  document.getElementById('saveScheduleBtn').click();
+
+  const saved = chromeMock._storage.get('scheduleConfig');
+  assert(saved !== undefined, 'scheduleConfig应保存到storage');
+  assertEqual(saved.enabled, true);
+  assertEqual(saved.time, '07:00');
+  assertEqual(saved.webhookUrl, 'https://feishu.webhook/test');
+
+  const sentMsg = chromeMock._sentMessages.find(m => m.action === 'updateScheduleConfig');
+  assert(sentMsg !== undefined, '应发送updateScheduleConfig消息');
+  assertEqual(sentMsg.scheduleConfig.enabled, true);
+});
+
+// ============================================================
+// 6. Diff模式高亮
 // ============================================================
 console.log('\n  ▶ Diff模式');
 


### PR DESCRIPTION
## 变更概述

新增定时任务功能，支持在 PT 勋章扫描器中配置每日自动扫描并通过飞书机器人推送扫描结果，同时添加了相应的单元测试和集成测试。

## 主要变更

- **manifest.json**: 添加 `alarms` 权限以支持定时任务
- **background.js**: 新增定时扫描、飞书推送、闹钟管理等功能
- **options/options.html**: 新增定时任务配置 UI
- **options/options.js**: 新增定时配置保存/加载/测试推送逻辑
- **测试文件**: 新增 chrome.alarms mock 及对应的单元测试和集成测试

## 详细变更

| 文件 | 变更说明 |
|------|---------|
| manifest.json | 添加 alarms 权限 |
| background.js | 新增 sendToFeishu、setupAlarm、performScheduledScan 函数，onStartup/onInstalled 监听器，alarms 事件处理 |
| options/options.html | 新增定时任务配置卡片（开关、时间、Webhook URL） |
| options/options.js | 新增定时配置的加载、保存、测试推送逻辑 |
| tests/mocks/chrome-mock.js | 新增 chrome.alarms 和 onStartup mock |
| tests/unit/background.test.js | 新增 sendToFeishu、setupAlarm 测试 |
| tests/unit/options.test.js | 新增定时配置 DOM 和存储测试 |
| tests/integration/messaging.test.js | 新增 action 匹配校验 |